### PR TITLE
MacPilot v3: chain commands, AX auto-relaunch, tests

### DIFF
--- a/Sources/MacPilot/AXCheckCommand.swift
+++ b/Sources/MacPilot/AXCheckCommand.swift
@@ -1,0 +1,30 @@
+import ArgumentParser
+import ApplicationServices
+import Foundation
+
+struct AXCheck: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "ax-check", abstract: "Check Accessibility (AX) trust status")
+
+    @Flag(name: .long) var json = false
+
+    func run() {
+        let trusted = AXIsProcessTrusted()
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let parentPID = getppid()
+        if json {
+            JSONOutput.print([
+                "status": "ok",
+                "trusted": trusted,
+                "pid": Int(pid),
+                "parentPid": Int(parentPID),
+                "message": trusted ? "AXIsProcessTrusted: YES" : "AXIsProcessTrusted: NO — launch via 'open -W -a MacPilot.app' for AX access",
+            ], json: true)
+        } else {
+            print("AXIsProcessTrusted: \(trusted ? "YES ✅" : "NO ❌")")
+            print("PID: \(pid), Parent PID: \(parentPID)")
+            if !trusted {
+                print("Tip: Launch via 'open -W -a /path/to/MacPilot.app --args ax-check' for AX access")
+            }
+        }
+    }
+}

--- a/Sources/MacPilot/ChainCommand.swift
+++ b/Sources/MacPilot/ChainCommand.swift
@@ -1,0 +1,45 @@
+import ArgumentParser
+import Foundation
+
+struct Chain: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "chain", abstract: "Execute multiple keyboard actions in sequence")
+
+    @Argument(help: "Actions: key combos (e.g. cmd+l), type:text, or sleep:ms")
+    var actions: [String]
+
+    @Option(name: .long, help: "Delay between actions in milliseconds (default 200)")
+    var delay: UInt32 = 200
+
+    @Flag(name: .long) var json = false
+
+    func run() {
+        var results: [[String: Any]] = []
+
+        for (i, action) in actions.enumerated() {
+            if i > 0 {
+                usleep(delay * 1000)
+            }
+
+            if action.hasPrefix("type:") {
+                let text = String(action.dropFirst(5))
+                KeyboardController.typeText(text)
+                results.append(["action": "type", "text": text, "status": "ok"])
+            } else if action.hasPrefix("sleep:") {
+                if let ms = UInt32(action.dropFirst(6)) {
+                    usleep(ms * 1000)
+                    results.append(["action": "sleep", "ms": Int(ms), "status": "ok"])
+                }
+            } else {
+                // Treat as key combo
+                KeyboardController.pressCombo(action)
+                results.append(["action": "key", "combo": action, "status": "ok"])
+            }
+        }
+
+        if json {
+            JSONOutput.print(["status": "ok", "message": "Executed \(actions.count) actions", "actions": results], json: true)
+        } else {
+            print("Executed \(actions.count) actions")
+        }
+    }
+}

--- a/Sources/MacPilot/ChromeCommand.swift
+++ b/Sources/MacPilot/ChromeCommand.swift
@@ -1,0 +1,95 @@
+import ArgumentParser
+import AppKit
+import Foundation
+
+struct Chrome: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "chrome",
+        abstract: "Chrome browser shortcuts",
+        subcommands: [ChromeOpenURL.self, ChromeNewTab.self, ChromeExtensions.self, ChromeDevMode.self]
+    )
+}
+
+/// Helper to ensure Chrome is focused before sending keystrokes
+private func focusChrome() {
+    if let chrome = NSWorkspace.shared.runningApplications.first(where: {
+        $0.bundleIdentifier == "com.google.Chrome"
+    }) {
+        chrome.activate(options: [.activateAllWindows])
+        usleep(400_000)
+    }
+}
+
+struct ChromeOpenURL: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "open-url", abstract: "Open URL in current tab (Cmd+L, type, Return)")
+
+    @Argument(help: "URL to open") var url: String
+    @Flag(name: .long) var json = false
+
+    func run() {
+        focusChrome()
+        KeyboardController.pressCombo("cmd+l")
+        usleep(200_000)
+        KeyboardController.typeText(url)
+        usleep(100_000)
+        KeyboardController.pressCombo("return")
+        JSONOutput.print(["status": "ok", "message": "Opened \(url) in Chrome"], json: json)
+    }
+}
+
+struct ChromeNewTab: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "new-tab", abstract: "Open URL in new tab (Cmd+T, type, Return)")
+
+    @Argument(help: "URL to open") var url: String
+    @Flag(name: .long) var json = false
+
+    func run() {
+        focusChrome()
+        KeyboardController.pressCombo("cmd+t")
+        usleep(300_000)
+        KeyboardController.typeText(url)
+        usleep(100_000)
+        KeyboardController.pressCombo("return")
+        JSONOutput.print(["status": "ok", "message": "Opened \(url) in new Chrome tab"], json: json)
+    }
+}
+
+struct ChromeExtensions: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "extensions", abstract: "Navigate to chrome://extensions")
+
+    @Flag(name: .long) var json = false
+
+    func run() {
+        focusChrome()
+        KeyboardController.pressCombo("cmd+l")
+        usleep(200_000)
+        KeyboardController.typeText("chrome://extensions")
+        usleep(100_000)
+        KeyboardController.pressCombo("return")
+        JSONOutput.print(["status": "ok", "message": "Navigated to chrome://extensions"], json: json)
+    }
+}
+
+struct ChromeDevMode: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "dev-mode", abstract: "Toggle developer mode in chrome://extensions")
+
+    @Flag(name: .long) var json = false
+
+    func run() {
+        focusChrome()
+        // Navigate to extensions page first
+        KeyboardController.pressCombo("cmd+l")
+        usleep(200_000)
+        KeyboardController.typeText("chrome://extensions")
+        usleep(100_000)
+        KeyboardController.pressCombo("return")
+        usleep(1_500_000) // Wait for page to load
+
+        // Tab to developer mode toggle and press Space
+        // The developer mode toggle is typically reachable via Tab from the main content
+        KeyboardController.pressCombo("tab")
+        usleep(200_000)
+        KeyboardController.pressCombo("space")
+        JSONOutput.print(["status": "ok", "message": "Toggled developer mode"], json: json)
+    }
+}

--- a/Sources/MacPilot/MacPilot.swift
+++ b/Sources/MacPilot/MacPilot.swift
@@ -6,7 +6,7 @@ struct MacPilot: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macpilot",
         abstract: "Programmatic macOS control for AI agents",
-        version: "0.1.0",
+        version: "0.3.0",
         subcommands: [
             Click.self,
             DoubleClick.self,
@@ -24,6 +24,11 @@ struct MacPilot: ParsableCommand {
             Dialog.self,
             Shell.self,
             Wait.self,
+            Space.self,
+            AXCheck.self,
+            Chain.self,
+            Chrome.self,
+            Run.self,
         ]
     )
 }

--- a/Sources/MacPilot/Overlay.swift
+++ b/Sources/MacPilot/Overlay.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Foundation
+
+/// Lightweight visual overlay for indicating MacPilot actions.
+/// Shows brief visual feedback (circles for clicks, borders for screenshots, etc.)
+/// Auto-dismisses after a short delay. Does not interfere with automation.
+enum Overlay {
+
+    /// Show a small circle at the given screen coordinates (for click feedback)
+    static func showClick(x: Double, y: Double, duration: TimeInterval = 0.4) {
+        showOverlay(duration: duration) { screen in
+            let size: CGFloat = 30
+            // Convert screen coords to window coords (top-left origin)
+            let frame = NSRect(x: x - Double(size/2), y: Double(screen.frame.maxY) - y - Double(size/2), width: Double(size), height: Double(size))
+            let window = makeWindow(frame: frame, screen: screen)
+            let view = ClickIndicatorView(frame: NSRect(origin: .zero, size: frame.size))
+            window.contentView = view
+            return window
+        }
+    }
+
+    /// Flash a border around the screen (for screenshot feedback)
+    static func showScreenFlash(duration: TimeInterval = 0.3) {
+        showOverlay(duration: duration) { screen in
+            let window = makeWindow(frame: screen.frame, screen: screen)
+            let view = BorderFlashView(frame: NSRect(origin: .zero, size: screen.frame.size))
+            window.contentView = view
+            return window
+        }
+    }
+
+    /// Show a small notification at top of screen with text (for keyboard feedback)
+    static func showKeyNotification(text: String, duration: TimeInterval = 0.5) {
+        showOverlay(duration: duration) { screen in
+            let width: CGFloat = min(CGFloat(text.count * 12 + 40), 300)
+            let height: CGFloat = 32
+            let x = screen.frame.midX - width / 2
+            let y = screen.frame.maxY - height - 40
+            let frame = NSRect(x: x, y: y, width: width, height: height)
+            let window = makeWindow(frame: frame, screen: screen)
+            let view = KeyNotificationView(frame: NSRect(origin: .zero, size: frame.size), text: text)
+            window.contentView = view
+            return window
+        }
+    }
+
+    // MARK: - Private
+
+    private static func makeWindow(frame: NSRect, screen: NSScreen) -> NSWindow {
+        let window = NSWindow(contentRect: frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.level = .floating
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.ignoresMouseEvents = true
+        window.hasShadow = false
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        return window
+    }
+
+    private static func showOverlay(duration: TimeInterval, builder: @escaping (NSScreen) -> NSWindow) {
+        // Run on main thread, but don't block
+        DispatchQueue.main.async {
+            guard let screen = NSScreen.main else { return }
+            let window = builder(screen)
+            window.orderFrontRegardless()
+
+            // Fade out and close
+            DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                NSAnimationContext.runAnimationGroup({ ctx in
+                    ctx.duration = 0.15
+                    window.animator().alphaValue = 0
+                }, completionHandler: {
+                    window.close()
+                })
+            }
+        }
+    }
+}
+
+// MARK: - Custom Views
+
+private class ClickIndicatorView: NSView {
+    override func draw(_ dirtyRect: NSRect) {
+        let path = NSBezierPath(ovalIn: bounds.insetBy(dx: 2, dy: 2))
+        NSColor.systemYellow.withAlphaComponent(0.8).setFill()
+        path.fill()
+        NSColor.systemOrange.setStroke()
+        path.lineWidth = 2
+        path.stroke()
+    }
+}
+
+private class BorderFlashView: NSView {
+    override func draw(_ dirtyRect: NSRect) {
+        let path = NSBezierPath(rect: bounds.insetBy(dx: 3, dy: 3))
+        NSColor.systemBlue.withAlphaComponent(0.6).setStroke()
+        path.lineWidth = 6
+        path.stroke()
+    }
+}
+
+private class KeyNotificationView: NSView {
+    let text: String
+    init(frame: NSRect, text: String) {
+        self.text = text
+        super.init(frame: frame)
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let path = NSBezierPath(roundedRect: bounds, xRadius: 8, yRadius: 8)
+        NSColor.black.withAlphaComponent(0.7).setFill()
+        path.fill()
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.white,
+            .font: NSFont.systemFont(ofSize: 14, weight: .medium),
+        ]
+        let str = NSAttributedString(string: text, attributes: attrs)
+        let size = str.size()
+        let origin = NSPoint(x: (bounds.width - size.width) / 2, y: (bounds.height - size.height) / 2)
+        str.draw(at: origin)
+    }
+}

--- a/Sources/MacPilot/RunCommand.swift
+++ b/Sources/MacPilot/RunCommand.swift
@@ -1,0 +1,89 @@
+import ArgumentParser
+import ApplicationServices
+import Foundation
+
+struct Run: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Re-launch a MacPilot subcommand via 'open -W' for AX access"
+    )
+
+    @Argument(parsing: .allUnrecognized, help: "Subcommand and arguments to pass")
+    var args: [String] = []
+
+    @Flag(name: .long) var json = false
+
+    func run() throws {
+        // Find our own .app bundle path
+        let execPath = ProcessInfo.processInfo.arguments[0]
+        let bundlePath = findBundlePath(execPath)
+
+        guard let appPath = bundlePath else {
+            JSONOutput.error("Cannot find .app bundle for re-launch. Exec path: \(execPath)", json: json)
+            throw ExitCode.failure
+        }
+
+        // Create temp files for output
+        let tmpDir = FileManager.default.temporaryDirectory
+        let outFile = tmpDir.appendingPathComponent("macpilot_run_\(ProcessInfo.processInfo.processIdentifier)_out.txt")
+        let errFile = tmpDir.appendingPathComponent("macpilot_run_\(ProcessInfo.processInfo.processIdentifier)_err.txt")
+
+        // Clean up any existing files
+        try? FileManager.default.removeItem(at: outFile)
+        try? FileManager.default.removeItem(at: errFile)
+        FileManager.default.createFile(atPath: outFile.path, contents: nil)
+        FileManager.default.createFile(atPath: errFile.path, contents: nil)
+
+        defer {
+            try? FileManager.default.removeItem(at: outFile)
+            try? FileManager.default.removeItem(at: errFile)
+        }
+
+        // Build the open command
+        // open -W -a /path/to/MacPilot.app --stdout /tmp/out --stderr /tmp/err --args <subcommand> <args...>
+        var openArgs = ["-W", "-a", appPath, "--stdout", outFile.path, "--stderr", errFile.path]
+        if !args.isEmpty {
+            openArgs.append("--args")
+            openArgs.append(contentsOf: args)
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = openArgs
+        try task.run()
+        task.waitUntilExit()
+
+        // Read and print output
+        let stdout = (try? String(contentsOf: outFile, encoding: .utf8)) ?? ""
+        let stderr = (try? String(contentsOf: errFile, encoding: .utf8)) ?? ""
+
+        if !stdout.isEmpty {
+            print(stdout, terminator: "")
+        }
+        if !stderr.isEmpty {
+            FileHandle.standardError.write(Data(stderr.utf8))
+        }
+
+        if task.terminationStatus != 0 {
+            throw ExitCode(task.terminationStatus)
+        }
+    }
+
+    /// Walk up from the executable to find the .app bundle
+    private func findBundlePath(_ execPath: String) -> String? {
+        var url = URL(fileURLWithPath: execPath).standardized
+        // Walk up looking for .app
+        for _ in 0..<5 {
+            url = url.deletingLastPathComponent()
+            if url.pathExtension == "app" {
+                return url.path
+            }
+        }
+        // Fallback: check if we know the standard path
+        let standardPath = "/Users/admin/clawd/tools/macpilot/MacPilot.app"
+        if FileManager.default.fileExists(atPath: standardPath) {
+            return standardPath
+        }
+        return nil
+    }
+}

--- a/Sources/MacPilot/SafetyChecks.swift
+++ b/Sources/MacPilot/SafetyChecks.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Safety checks to prevent dangerous operations.
+/// MacPilot MUST NOT: kill system processes, modify system files, or touch TCC databases.
+enum Safety {
+
+    /// System processes that must never be killed
+    static let protectedProcesses: Set<String> = [
+        "Finder", "WindowServer", "Dock", "SystemUIServer", "launchd",
+        "kernel_task", "loginwindow", "cfprefsd", "lsd", "mds",
+        "notifyd", "distnoted", "securityd", "trustd", "tccd",
+        "coreservicesd", "opendirectoryd", "syslogd", "powerd",
+        "diskarbitrationd", "configd", "UserEventAgent",
+    ]
+
+    /// Paths that must never be modified
+    static let protectedPaths: [String] = [
+        "/System/",
+        "/Library/",
+        "/usr/",
+        "/bin/",
+        "/sbin/",
+        "/private/var/db/TCC/",
+        "/etc/sudoers",
+        "/etc/hosts",
+    ]
+
+    /// Check if an app name is a protected system process
+    static func isProtectedProcess(_ name: String) -> Bool {
+        return protectedProcesses.contains(where: { name.localizedCaseInsensitiveCompare($0) == .orderedSame })
+    }
+
+    /// Check if a path is protected
+    static func isProtectedPath(_ path: String) -> Bool {
+        let resolved = (path as NSString).standardizingPath
+        return protectedPaths.contains(where: { resolved.hasPrefix($0) })
+    }
+
+    /// Validate that a quit/kill operation is safe
+    static func validateQuit(appName: String) -> String? {
+        if isProtectedProcess(appName) {
+            return "REFUSED: '\(appName)' is a protected system process. MacPilot will never kill system processes."
+        }
+        return nil
+    }
+
+    /// Validate that a shell command is safe
+    static func validateShellCommand(_ command: String) -> String? {
+        let lower = command.lowercased()
+
+        // Block TCC database access
+        if lower.contains("tcc.db") || lower.contains("/tcc/") {
+            return "REFUSED: MacPilot will never access TCC databases."
+        }
+
+        // Block rm -rf on system dirs
+        if lower.contains("rm ") && (lower.contains("/system") || lower.contains("/library") || lower.contains("/usr")) {
+            return "REFUSED: MacPilot will never delete system files."
+        }
+
+        // Block killing system processes
+        if (lower.contains("kill ") || lower.contains("killall ")) {
+            for proc in protectedProcesses {
+                if lower.contains(proc.lowercased()) {
+                    return "REFUSED: MacPilot will never kill system process '\(proc)'."
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/MacPilot/ShellCommands.swift
+++ b/Sources/MacPilot/ShellCommands.swift
@@ -16,6 +16,12 @@ struct ShellRun: ParsableCommand {
     @Flag(name: .long) var json = false
 
     func run() throws {
+        // Safety check
+        if let reason = Safety.validateShellCommand(command) {
+            JSONOutput.error(reason, json: json)
+            throw ExitCode.failure
+        }
+
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/bash")
         task.arguments = ["-c", command]

--- a/Sources/MacPilot/SpaceCommands.swift
+++ b/Sources/MacPilot/SpaceCommands.swift
@@ -1,0 +1,291 @@
+import ArgumentParser
+import AppKit
+import CoreGraphics
+import Foundation
+
+struct Space: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Space/desktop management",
+        subcommands: [SpaceList.self, SpaceSwitch.self, SpaceBring.self]
+    )
+}
+
+// MARK: - CGS Private API declarations
+
+// Connection to the window server
+@_silgen_name("CGSMainConnectionID")
+func CGSMainConnectionID() -> Int
+
+@_silgen_name("CGSCopySpaces")
+func CGSCopySpaces(_ connection: Int, _ mask: Int) -> CFArray
+
+@_silgen_name("CGSGetActiveSpace")
+func CGSGetActiveSpace(_ connection: Int) -> Int
+
+@_silgen_name("CGSCopyWindowsWithOptionsAndTags")
+func CGSCopyWindowsWithOptionsAndTags(_ connection: Int, _ owner: Int, _ spaces: CFArray, _ options: Int, _ setTags: UnsafeMutablePointer<UInt64>?, _ clearTags: UnsafeMutablePointer<UInt64>?) -> CFArray?
+
+// Space masks for CGSCopySpaces
+let kCGSSpaceCurrent: Int = 5   // current space
+let kCGSSpaceOther: Int = 6     // other spaces
+let kCGSSpaceAll: Int = 7       // all spaces
+let kCGSSpaceUser: Int = 1      // user spaces only
+
+struct SpaceList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List all Spaces/desktops")
+
+    @Flag(name: .long) var json = false
+
+    func run() throws {
+        let conn = CGSMainConnectionID()
+        let activeSpace = CGSGetActiveSpace(conn)
+
+        // Get all user spaces
+        let spacesRef = CGSCopySpaces(conn, kCGSSpaceAll)
+        let spaces = spacesRef as? [Int] ?? []
+
+        // Also get user-only spaces for filtering
+        let userSpacesRef = CGSCopySpaces(conn, kCGSSpaceUser)
+        let userSpaces = Set(userSpacesRef as? [Int] ?? [])
+
+        var results: [[String: Any]] = []
+        var index = 1
+        for spaceID in spaces {
+            let isUser = userSpaces.contains(spaceID)
+            let isCurrent = spaceID == activeSpace
+            let info: [String: Any] = [
+                "id": spaceID,
+                "index": index,
+                "current": isCurrent,
+                "type": isUser ? "user" : "system",
+            ]
+            results.append(info)
+            index += 1
+        }
+
+        if json {
+            JSONOutput.printArray(results, json: true)
+        } else {
+            for r in results {
+                let id = r["id"] as? Int ?? 0
+                let idx = r["index"] as? Int ?? 0
+                let current = (r["current"] as? Bool ?? false) ? " (active)" : ""
+                let type = r["type"] as? String ?? ""
+                print("Space \(idx): id=\(id) type=\(type)\(current)")
+            }
+        }
+    }
+}
+
+struct SpaceSwitch: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "switch", abstract: "Switch to Space N or left/right")
+
+    @Option(name: .long, help: "Space index (1-based)") var index: Int?
+    @Option(name: .long, help: "Direction: left or right") var direction: String?
+    @Flag(name: .long) var json = false
+
+    func run() throws {
+        if let dir = direction {
+            // Use Ctrl+Left/Right arrow — these are system shortcuts
+            // Try AppleScript approach which is more reliable for system shortcuts
+            let keyCode: String
+            switch dir.lowercased() {
+            case "left": keyCode = "123"   // left arrow
+            case "right": keyCode = "124"  // right arrow
+            default:
+                JSONOutput.error("Direction must be 'left' or 'right'", json: json)
+                throw ExitCode.failure
+            }
+
+            // Use AppleScript to trigger the key event (more reliable for system shortcuts)
+            let script = """
+            tell application "System Events"
+                key code \(keyCode) using control down
+            end tell
+            """
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            task.arguments = ["-e", script]
+            let pipe = Pipe()
+            task.standardError = pipe
+            try task.run()
+            task.waitUntilExit()
+
+            if task.terminationStatus == 0 {
+                JSONOutput.print(["status": "ok", "message": "Switched Space \(dir)"], json: json)
+            } else {
+                // Fallback to CGEvent
+                let code: UInt16 = dir.lowercased() == "left" ? 123 : 124
+                let src = CGEventSource(stateID: .hidSystemState)
+                let down = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: true)
+                let up = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: false)
+                down?.flags = .maskControl
+                up?.flags = .maskControl
+                down?.post(tap: .cghidEventTap)
+                up?.post(tap: .cghidEventTap)
+                JSONOutput.print(["status": "ok", "message": "Switched Space \(dir) (CGEvent fallback)"], json: json)
+            }
+            return
+        }
+
+        guard let index = index, index >= 1 && index <= 9 else {
+            JSONOutput.error("Provide --index (1-9) or --direction (left/right)", json: json)
+            throw ExitCode.failure
+        }
+
+        // Use AppleScript for Ctrl+N (more reliable than CGEvent for system shortcuts)
+        let keyCodes: [Int: Int] = [
+            1: 18, 2: 19, 3: 20, 4: 21, 5: 23,
+            6: 22, 7: 26, 8: 28, 9: 25
+        ]
+
+        guard let keyCode = keyCodes[index] else {
+            JSONOutput.error("Invalid index", json: json)
+            throw ExitCode.failure
+        }
+
+        let script = """
+        tell application "System Events"
+            key code \(keyCode) using control down
+        end tell
+        """
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", script]
+        try task.run()
+        task.waitUntilExit()
+
+        if task.terminationStatus == 0 {
+            JSONOutput.print(["status": "ok", "message": "Switched to Space \(index)"], json: json)
+        } else {
+            // Fallback to CGEvent
+            let src = CGEventSource(stateID: .hidSystemState)
+            let down = CGEvent(keyboardEventSource: src, virtualKey: UInt16(keyCode), keyDown: true)
+            let up = CGEvent(keyboardEventSource: src, virtualKey: UInt16(keyCode), keyDown: false)
+            down?.flags = .maskControl
+            up?.flags = .maskControl
+            down?.post(tap: .cghidEventTap)
+            up?.post(tap: .cghidEventTap)
+            JSONOutput.print(["status": "ok", "message": "Switched to Space \(index) (CGEvent fallback)"], json: json)
+        }
+    }
+}
+
+struct SpaceBring: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "bring", abstract: "Bring an app from any Space to the current one")
+
+    @Option(name: .long, help: "App name") var app: String
+    @Flag(name: .long) var json = false
+
+    func run() throws {
+        // 1. Find the app
+        guard let runApp = NSWorkspace.shared.runningApplications.first(where: {
+            $0.localizedName?.localizedCaseInsensitiveContains(app) == true
+        }) else {
+            JSONOutput.error("App '\(app)' not found", json: json)
+            throw ExitCode.failure
+        }
+
+        let pid = runApp.processIdentifier
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // First, check if we can already see windows (app on current Space)
+        var value: AnyObject?
+        var windows: [AXUIElement] = []
+        if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
+           let w = value as? [AXUIElement], !w.isEmpty {
+            windows = w
+        }
+
+        // Check if any windows are in fullscreen
+        var hasFullscreenWindow = false
+        for win in windows {
+            var fsValue: AnyObject?
+            if AXUIElementCopyAttributeValue(win, "AXFullScreen" as CFString, &fsValue) == .success,
+               let isFS = fsValue as? Bool, isFS {
+                hasFullscreenWindow = true
+                break
+            }
+        }
+
+        // If no windows visible via AX, or has fullscreen windows, need special handling
+        if windows.isEmpty || hasFullscreenWindow {
+            // Strategy: Activate app (switches to its Space), send Cmd+Ctrl+F or
+            // use green button equivalent to exit fullscreen, wait, then it merges back
+
+            // Activate the app - macOS switches to its fullscreen Space
+            runApp.activate(options: [.activateAllWindows])
+            usleep(800_000)
+
+            // Re-fetch windows now that we're on the app's Space
+            if windows.isEmpty {
+                for _ in 0..<8 {
+                    var v2: AnyObject?
+                    if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &v2) == .success,
+                       let w = v2 as? [AXUIElement], !w.isEmpty {
+                        windows = w
+                        break
+                    }
+                    usleep(300_000)
+                }
+            }
+
+            // Exit fullscreen via AX attribute
+            var exitedFullscreen = false
+            for win in windows {
+                var fsValue: AnyObject?
+                if AXUIElementCopyAttributeValue(win, "AXFullScreen" as CFString, &fsValue) == .success,
+                   let isFS = fsValue as? Bool, isFS {
+                    AXUIElementSetAttributeValue(win, "AXFullScreen" as CFString, false as CFBoolean)
+                    exitedFullscreen = true
+                }
+            }
+
+            if !exitedFullscreen && windows.isEmpty {
+                // Last resort: send keyboard shortcut to exit fullscreen
+                // Cmd+Ctrl+F is the macOS standard fullscreen toggle
+                let src = CGEventSource(stateID: .hidSystemState)
+                // keycode 3 = 'f'
+                let down = CGEvent(keyboardEventSource: src, virtualKey: 3, keyDown: true)
+                let up = CGEvent(keyboardEventSource: src, virtualKey: 3, keyDown: false)
+                down?.flags = [.maskCommand, .maskControl]
+                up?.flags = [.maskCommand, .maskControl]
+                down?.post(tap: .cghidEventTap)
+                up?.post(tap: .cghidEventTap)
+                exitedFullscreen = true
+            }
+
+            if exitedFullscreen {
+                // Wait for fullscreen exit animation
+                usleep(1_800_000)
+                // Re-fetch windows
+                var v3: AnyObject?
+                if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &v3) == .success,
+                   let w = v3 as? [AXUIElement], !w.isEmpty {
+                    windows = w
+                }
+            }
+        }
+
+        // Move windows to visible area on current screen
+        let screen = NSScreen.main ?? NSScreen.screens[0]
+        let visibleFrame = screen.visibleFrame
+        let screenFrame = screen.frame
+        let axY = screenFrame.maxY - visibleFrame.maxY
+
+        for win in windows {
+            var point = CGPoint(x: visibleFrame.origin.x + 50, y: axY + 50)
+            if let posValue = AXValueCreate(.cgPoint, &point) {
+                AXUIElementSetAttributeValue(win, kAXPositionAttribute as CFString, posValue)
+            }
+        }
+
+        // Activate the app
+        runApp.activate(options: [.activateAllWindows])
+
+        let msg = windows.isEmpty
+            ? "Activated '\(runApp.localizedName ?? app)' (could not access windows)"
+            : "Brought '\(runApp.localizedName ?? app)' to current space"
+        JSONOutput.print(["status": "ok", "message": msg, "windowCount": windows.count], json: json)
+    }
+}

--- a/Tests/MacPilotTests/MacPilotTests.swift
+++ b/Tests/MacPilotTests/MacPilotTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+import Foundation
+
+/// Integration tests for MacPilot CLI.
+/// These tests invoke the built binary and verify output.
+final class MacPilotTests: XCTestCase {
+
+    /// Path to the MacPilot binary
+    static let binaryPath = "/Users/admin/clawd/tools/macpilot/MacPilot.app/Contents/MacOS/MacPilot"
+
+    // MARK: - Helpers
+
+    @discardableResult
+    func runMacPilot(_ args: [String], expectSuccess: Bool = true) throws -> (stdout: String, stderr: String, exitCode: Int32) {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: Self.binaryPath)
+        task.arguments = args
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+
+        try task.run()
+        task.waitUntilExit()
+
+        let stdout = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        if expectSuccess {
+            XCTAssertEqual(task.terminationStatus, 0, "Expected success but got exit code \(task.terminationStatus). stderr: \(stderr)")
+        }
+
+        return (stdout, stderr, task.terminationStatus)
+    }
+
+    // MARK: - Tests
+
+    func testAXCheck() throws {
+        let result = try runMacPilot(["ax-check", "--json"])
+        XCTAssertTrue(result.stdout.contains("AXIsProcessTrusted"))
+        // Should parse as valid JSON
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["status"] as? String, "ok")
+        XCTAssertNotNil(json["trusted"])
+    }
+
+    func testScreenshot() throws {
+        let tmpPath = "/tmp/macpilot_test_screenshot.png"
+        try? FileManager.default.removeItem(atPath: tmpPath)
+
+        let result = try runMacPilot(["screenshot", "--output", tmpPath, "--json"])
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["status"] as? String, "ok")
+        XCTAssertEqual(json["path"] as? String, tmpPath)
+
+        // Verify file exists and has content
+        let fileData = try Data(contentsOf: URL(fileURLWithPath: tmpPath))
+        XCTAssertGreaterThan(fileData.count, 1000, "Screenshot should be more than 1KB")
+
+        try? FileManager.default.removeItem(atPath: tmpPath)
+    }
+
+    func testAppList() throws {
+        let result = try runMacPilot(["app", "list", "--json"])
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        XCTAssertGreaterThan(json.count, 0, "Should have at least 1 running app")
+        // Finder should always be running
+        let finderFound = json.contains { ($0["name"] as? String) == "Finder" }
+        XCTAssertTrue(finderFound, "Finder should be in the app list")
+    }
+
+    func testSpaceList() throws {
+        let result = try runMacPilot(["space", "list", "--json"])
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        XCTAssertGreaterThanOrEqual(json.count, 1, "Should have at least 1 space")
+        // At least one should be current
+        let hasCurrent = json.contains { ($0["current"] as? Bool) == true }
+        XCTAssertTrue(hasCurrent, "Should have an active space")
+    }
+
+    func testClipboard() throws {
+        let testText = "MacPilot_test_\(Int.random(in: 1000...9999))"
+        try runMacPilot(["clipboard", "set", testText, "--json"])
+        let result = try runMacPilot(["clipboard", "get", "--json"])
+        XCTAssertTrue(result.stdout.contains(testText))
+    }
+
+    func testChainDryRun() throws {
+        // Just verify the chain command parses correctly with --json
+        // Using sleep:0 actions to avoid actual key events during tests
+        let result = try runMacPilot(["chain", "sleep:10", "sleep:10", "--delay", "10", "--json"])
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["status"] as? String, "ok")
+        XCTAssertTrue(result.stdout.contains("2 actions"))
+    }
+
+    func testSafetyBlocksSystemProcess() throws {
+        let result = try runMacPilot(["app", "quit", "WindowServer", "--json"], expectSuccess: false)
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.stdout.contains("REFUSED") || result.stderr.contains("REFUSED"),
+                       "Should refuse to quit system process")
+    }
+
+    func testSafetyBlocksDangerousShell() throws {
+        let result = try runMacPilot(["shell", "run", "rm -rf /System/test", "--json"], expectSuccess: false)
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(result.stdout.contains("REFUSED") || result.stderr.contains("REFUSED"),
+                       "Should refuse dangerous shell command")
+    }
+
+    func testKeyCodeMapping() throws {
+        // Verify all basic keys map to non-zero codes (except 'a' which is 0)
+        // We test by running key command with --json and checking it succeeds
+        let result = try runMacPilot(["key", "escape", "--json"])
+        XCTAssertTrue(result.stdout.contains("ok"))
+    }
+
+    func testVersion() throws {
+        let result = try runMacPilot(["--version"])
+        XCTAssertTrue(result.stdout.contains("0.3.0"))
+    }
+
+    func testWindowListAllSpaces() throws {
+        let result = try runMacPilot(["window", "list", "--all-spaces", "--json"])
+        let data = result.stdout.data(using: .utf8)!
+        let json = try JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        XCTAssertGreaterThan(json.count, 0, "Should have at least 1 window")
+    }
+}

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# MacPilot integration tests
+# Run: bash Tests/run_tests.sh
+
+MP="/Users/admin/clawd/tools/macpilot/MacPilot.app/Contents/MacOS/MacPilot"
+PASS=0
+FAIL=0
+
+assert_contains() {
+    local test_name="$1" output="$2" expected="$3"
+    if echo "$output" | grep -q "$expected"; then
+        echo "✅ $test_name"
+        ((PASS++))
+    else
+        echo "❌ $test_name — expected '$expected' in output"
+        ((FAIL++))
+    fi
+}
+
+assert_exit_code() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        echo "✅ $test_name"
+        ((PASS++))
+    else
+        echo "❌ $test_name — expected exit code $expected, got $actual"
+        ((FAIL++))
+    fi
+}
+
+echo "=== MacPilot Integration Tests ==="
+echo ""
+
+# Test: version
+out=$($MP --version 2>&1)
+assert_contains "version" "$out" "0.3.0"
+
+# Test: ax-check
+out=$($MP ax-check --json 2>&1)
+assert_contains "ax-check returns JSON" "$out" '"status" : "ok"'
+assert_contains "ax-check has trusted field" "$out" '"trusted"'
+
+# Test: screenshot
+tmpfile="/tmp/macpilot_test_screenshot.png"
+rm -f "$tmpfile"
+out=$($MP screenshot --output "$tmpfile" --json 2>&1)
+assert_contains "screenshot JSON" "$out" '"status" : "ok"'
+if [ -f "$tmpfile" ] && [ "$(stat -f%z "$tmpfile")" -gt 1000 ]; then
+    echo "✅ screenshot file created and >1KB"
+    ((PASS++))
+else
+    echo "❌ screenshot file missing or too small"
+    ((FAIL++))
+fi
+rm -f "$tmpfile"
+
+# Test: app list
+out=$($MP app list --json 2>&1)
+assert_contains "app list has Finder" "$out" "Finder"
+
+# Test: space list
+out=$($MP space list --json 2>&1)
+assert_contains "space list has current" "$out" '"current" : true'
+
+# Test: clipboard
+rand=$((RANDOM))
+$MP clipboard set "test_$rand" --json > /dev/null 2>&1
+out=$($MP clipboard get --json 2>&1)
+assert_contains "clipboard roundtrip" "$out" "test_$rand"
+
+# Test: chain with sleep actions
+out=$($MP chain "sleep:10" "sleep:10" --delay 10 --json 2>&1)
+assert_contains "chain executes" "$out" '"status" : "ok"'
+assert_contains "chain action count" "$out" "2 actions"
+
+# Test: safety - block system process quit
+out=$($MP app quit WindowServer --json 2>&1) || true
+assert_contains "safety blocks WindowServer quit" "$out" "REFUSED"
+
+# Test: safety - block dangerous shell
+out=$($MP shell run "rm -rf /System/test" --json 2>&1) || true
+assert_contains "safety blocks rm system" "$out" "REFUSED"
+
+# Test: safety - block TCC access
+out=$($MP shell run "sqlite3 /private/var/db/TCC/TCC.db .tables" --json 2>&1) || true
+assert_contains "safety blocks TCC" "$out" "REFUSED"
+
+# Test: window list --all-spaces
+out=$($MP window list --all-spaces --json 2>&1)
+assert_contains "window list returns data" "$out" '"app"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## New Commands

- **`ax-check`** — Check AXIsProcessTrusted status (JSON output with pid info)
- **`chain`** — Execute multiple keyboard actions in sequence: `chain "cmd+l" "type:url" "return" --delay 300`
- **`chrome`** — Browser shortcuts: `open-url`, `new-tab`, `extensions`, `dev-mode`
- **`run`** — Re-launch subcommand via `open -W` for AX access when spawned as child process

## Improvements

- **Space switching** uses AppleScript (System Events) instead of CGEvent for reliable system shortcut triggering
- **Safety checks** block killing system processes (WindowServer, Finder, etc.), dangerous shell commands (rm on /System), and TCC database access
- Version bumped to 0.3.0

## Tests

14 integration tests via `Tests/run_tests.sh` covering all major functionality.